### PR TITLE
Add dual-function, source chart, to render-helm-chart function

### DIFF
--- a/cmd/krm-helm-upgrader/main.go
+++ b/cmd/krm-helm-upgrader/main.go
@@ -67,7 +67,7 @@ func handleNewVersion(new t.HelmChartArgs, curr t.HelmChartArgs, kubeObject *fn.
 			upgraded.Version = new.Version
 		}
 		if Config.AnnotateSumOnUpgradeAvailable {
-			_, chartSum, err := helm.PullChart(new)
+			_, chartSum, err := helm.PullChart(new, "")
 			if err != nil {
 				return nil, err
 			}
@@ -88,7 +88,7 @@ func handleNewVersion(new t.HelmChartArgs, curr t.HelmChartArgs, kubeObject *fn.
 		fmt.Fprintf(os.Stderr, "{\"current\": %s, \"upgraded\": %s, \"constraint\": %q}\n", string(curr_json), string(upgraded_json), upgradeConstraint)
 	} else {
 		if Config.AnnotateCurrentSum && kubeObject.GetAnnotation(annotationShaSum) == "" {
-			_, chartSum, err := helm.PullChart(curr)
+			_, chartSum, err := helm.PullChart(curr, "")
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/krm-render-helm-chart/main.go
+++ b/cmd/krm-render-helm-chart/main.go
@@ -107,11 +107,17 @@ func Run(rl *fn.ResourceList) (bool, error) {
 }
 
 func (chart *HelmChart) SourceChart() ([]byte, string, error) {
-	tarball, chartSum, err := helm.PullChart(chart.Args)
+	tmpDir, err := os.MkdirTemp("", "chart-")
 	if err != nil {
 		return nil, "", err
 	}
-	buf, err := os.ReadFile(tarball)
+	defer os.RemoveAll(tmpDir)
+
+	tarball, chartSum, err := helm.PullChart(chart.Args, tmpDir)
+	if err != nil {
+		return nil, "", err
+	}
+	buf, err := os.ReadFile(filepath.Join(tmpDir, tarball))
 	if err != nil {
 		return nil, "", err
 	}

--- a/examples/render-helm-chart/cert-manager-chart.yaml
+++ b/examples/render-helm-chart/cert-manager-chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: experimental.helm.sh/v1alpha1
+apiVersion: fn.kpt.dev/v1alpha1
 kind: RenderHelmChart
 metadata:
   name: render-chart


### PR DESCRIPTION
Add dual function to `render-helm-chart`. If an `apiVersion: experimental.helm.sh` is received, the embedded chart is rendered, if an `apiVersion: fn.kpt.dev` is received, the chart-sourcing function is triggered and a `apiVersion: experimental.helm.sh` resource is output.