### PR TITLE
Skip setting path annotation

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,11 +1,6 @@
 name: Run lint
 
 on:
-  push:
-    paths-ignore:
-      - 'README.md'
-      - 'scripts/**'
-      - 'docs/**'
   pull_request:
     paths-ignore:
       - 'README.md'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,9 @@ jobs:
     - name: checkout code
       uses: actions/checkout@v3
 
+    - name: build local binaries for test
+      run: make build
+
     - name: install kpt
       run: |
         curl -sLO https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.38/kpt_linux_amd64-1.0.0-beta.38.tar.gz

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,12 +1,22 @@
 name: Run tests
 
-on: [ push, pull_request ]
+on: [ pull_request ]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
+    - name: checkout code
       uses: actions/checkout@v3
-    - name: Test
+
+    - name: install kpt
+      run: |
+        curl -sLO https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.38/kpt_linux_amd64-1.0.0-beta.38.tar.gz
+        tar -xzf kpt_linux_amd64-1.0.0-beta.38.tar.gz
+        mv kpt /usr/local/bin/
+
+    - name: code tests
       run: make test GOFLAGS="-v"
+
+    - name: e2e tests
+      run: make e2e-tests

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,58 @@
+linters-settings:
+  errcheck:
+    check-type-assertions: true
+  goconst:
+    min-len: 2
+    min-occurrences: 3
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+  govet:
+    check-shadowing: true
+    enable:
+      - fieldalignment
+  nolintlint:
+    require-explanation: true
+    require-specific: true
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - exhaustive
+    - goconst
+    - gocritic
+    - goimports
+    - gocyclo
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nolintlint
+    - nakedret
+    - prealloc
+    - predeclared
+    - revive
+    - staticcheck
+    - stylecheck
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
+
+run:
+  issues-exit-code: 1
+  skip-dirs:
+    - test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 -include Makefile.local
+-include Makefile.test
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/Makefile.test
+++ b/Makefile.test
@@ -2,7 +2,7 @@ HELM_UPGRADER_BIN := bin/linux_amd64/krm-helm-upgrader
 HELM_RENDER_BIN := bin/linux_amd64/krm-render-helm-chart
 BASELINE_RENDER_HELM_CHART := gcr.io/kpt-fn/render-helm-chart:v0.2.2
 
-e2e-tests: test-render-helm-chart test-helm-upgrader
+e2e-tests: test-render-helm-chart render-helm-chart-example test-helm-upgrader
 
 .PHONY: test-helm-upgrader
 test-helm-upgrader:
@@ -26,3 +26,12 @@ test-render-helm-chart:
 	kpt fn source rendered-output2 | kpt fn eval - --exec ${HELM_RENDER_BIN} | kpt fn sink rendered-output3
 	diff -q rendered-output rendered-output3
 	rm -rf rendered-output rendered-output2 rendered-output3
+
+# Example usage from docs/render-helm-chart.md
+.PHONY: render-helm-chart-example
+render-helm-chart-example:
+	kpt fn source examples/render-helm-chart | kpt fn eval - --exec ${HELM_RENDER_BIN} | kpt fn sink my-cert-manager-package
+	grep -q 'apiVersion: experimental.helm.sh/v1alpha1' my-cert-manager-package/cert-manager-chart.yaml
+	cp examples/render-helm-chart/Kptfile my-cert-manager-package/
+	kpt fn render my-cert-manager-package -o stdout | grep -q 'team_name: blue-team'
+	rm -rf my-cert-manager-package

--- a/Makefile.test
+++ b/Makefile.test
@@ -1,0 +1,28 @@
+HELM_UPGRADER_BIN := bin/linux_amd64/krm-helm-upgrader
+HELM_RENDER_BIN := bin/linux_amd64/krm-render-helm-chart
+BASELINE_RENDER_HELM_CHART := gcr.io/kpt-fn/render-helm-chart:v0.2.2
+
+e2e-tests: test-render-helm-chart test-helm-upgrader
+
+.PHONY: test-helm-upgrader
+test-helm-upgrader:
+	kpt fn source examples/helm-upgrader --fn-config example-function-configs/config-upgrade-helm-version-inline.yaml | $(HELM_UPGRADER_BIN) > test-out.yaml
+	grep -e '.*upgrade-available: .*cert-manager:v1.8.2' test-out.yaml
+	grep -e '.*upgrade-available.0: .*cert-manager:v1.12.1' test-out.yaml
+	grep -e '.*upgrade-available.0: .*metacontroller-helm:v4.10.0' test-out.yaml
+	#grep -e '.*upgrade-available.1: .*/external-secrets:0.8.1' test-out.yaml
+	rm test-out.yaml
+
+.PHONY: test-render-helm-chart
+test-render-helm-chart:
+	# For reference, render chart using baseline function
+	rm -rf rendered-output
+	echo "" | kpt fn eval - --network --fn-config examples/render-helm-chart2/argo-workflows.yaml -i ${BASELINE_RENDER_HELM_CHART} | kpt fn sink rendered-output
+	# Source step, fetch chart from upstream, but do not render
+	rm -rf rendered-output2
+	kpt fn source examples/render-helm-chart2 | kpt fn eval - --exec ${HELM_RENDER_BIN} | kpt fn sink rendered-output2
+	# Render from previously sourced chart
+	rm -rf rendered-output3
+	kpt fn source rendered-output2 | kpt fn eval - --exec ${HELM_RENDER_BIN} | kpt fn sink rendered-output3
+	diff -q rendered-output rendered-output3
+	rm -rf rendered-output rendered-output2 rendered-output3

--- a/cmd/krm-render-helm-chart/main.go
+++ b/cmd/krm-render-helm-chart/main.go
@@ -42,8 +42,8 @@ func ParseRenderSpec(b []byte) (*RenderHelmChart, error) {
 
 func Run(rl *fn.ResourceList) (bool, error) {
 	var outputs fn.KubeObjects
-	//cfg := rl.FunctionConfig
-	//parseConfig(cfg)
+	// cfg := rl.FunctionConfig
+	// parseConfig(cfg)
 
 	for _, kubeObject := range rl.Items {
 		if kubeObject.IsGVK("experimental.helm.sh", "", "RenderHelmChart") {
@@ -52,13 +52,13 @@ func Run(rl *fn.ResourceList) (bool, error) {
 			if err != nil {
 				return false, err
 			}
-			for idx, chart := range spec.Charts {
-				if chart.Options.ReleaseName == "" {
+			for idx := range spec.Charts {
+				if spec.Charts[idx].Options.ReleaseName == "" {
 					return false, fmt.Errorf("Invalid chart spec %s: ReleaseName required, index %d", kubeObject.GetName(), idx)
 				}
 			}
-			for _, chart := range spec.Charts {
-				newobjs, err := chart.Template()
+			for idx := range spec.Charts {
+				newobjs, err := spec.Charts[idx].Template()
 				if err != nil {
 					return false, err
 				}
@@ -214,8 +214,8 @@ func (chart *HelmChart) Template() (fn.KubeObjects, error) {
 			if err != nil {
 				return nil, err
 			}
-			defer file.Close()
 			_, err =io.Copy(file, tr)
+			file.Close()
 			if err != nil {
 				return nil, err
 			}
@@ -228,8 +228,7 @@ func (chart *HelmChart) Template() (fn.KubeObjects, error) {
 		return nil, err
 	}
 	args := chart.buildHelmTemplateArgs()
-	args = append(args, "--values", valuesFile)
-	args = append(args, filepath.Join(tmpDir, chart.Args.Name))
+	args = append(args, "--values", valuesFile, filepath.Join(tmpDir, chart.Args.Name))
 
 	helmCtxt := helm.NewRunContext()
 	defer helmCtxt.DiscardContext()
@@ -315,7 +314,7 @@ func (chart *HelmChart) buildHelmTemplateArgs() []string {
 }
 
 func main() {
-	//fmt.Fprintf(os.Stderr, "version: %s\n", version.Version)
+	// fmt.Fprintf(os.Stderr, "version: %s\n", version.Version)
 	if err := fn.AsMain(fn.ResourceListProcessorFunc(Run)); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/krm-render-helm-chart/main.go
+++ b/cmd/krm-render-helm-chart/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/michaelvl/helm-upgrader/pkg/helm"
 	t "github.com/michaelvl/helm-upgrader/pkg/helmspecs"
 	"sigs.k8s.io/kustomize/kyaml/kio"
-	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 	"github.com/GoogleContainerTools/kpt-functions-sdk/go/fn"
 )
@@ -254,18 +253,20 @@ func (chart *HelmChart) Template() (fn.KubeObjects, error) {
 			}
 			return nil, fmt.Errorf("failed to parse %s: %s", nodes[i].MustString(), err.Error())
 		}
-		annoVal := fmt.Sprintf("%s/%s/%s_%s.yaml",
-			chart.Args.Name, chart.Options.ReleaseName, strings.ToLower(o.GetKind()), o.GetName())
-		currAnno := o.GetAnnotations()
-		if len(currAnno) == 0 {
-			currAnno = map[string]string{kioutil.PathAnnotation: annoVal}
-		} else {
-			currAnno[kioutil.PathAnnotation] = annoVal
-		}
-		err = o.SetNestedStringMap(currAnno, "metadata", "annotations")
-		if err != nil {
-			return nil, err
-		}
+		// The sink function conveniently sets path if none is defined
+
+		// annoVal := fmt.Sprintf("%s/%s/%s_%s.yaml",
+		// 	chart.Args.Name, chart.Options.ReleaseName, strings.ToLower(o.GetKind()), o.GetName())
+		// currAnno := o.GetAnnotations()
+		// if len(currAnno) == 0 {
+		// 	currAnno = map[string]string{kioutil.PathAnnotation: annoVal}
+		// } else {
+		// 	currAnno[kioutil.PathAnnotation] = annoVal
+		// }
+		// err = o.SetNestedStringMap(currAnno, "metadata", "annotations")
+		// if err != nil {
+		// 	return nil, err
+		// }
 		objects = append(objects, o)
 	}
 

--- a/docs/helm-upgrader.md
+++ b/docs/helm-upgrader.md
@@ -96,6 +96,8 @@ metadata:
     experimental.helm.sh/upgrade-constraint: "1.8.*"
 ```
 
+See also [supported upgrade constraints format](https://github.com/Masterminds/semver).
+
 ### Annotate Instead of Upgrade
 
 ```

--- a/docs/render-helm-chart.md
+++ b/docs/render-helm-chart.md
@@ -124,40 +124,6 @@ resource to the output. This is different that the [upstream
 `render-helm-chart`](https://catalog.kpt.dev/render-helm-chart/v0.2/)
 which reads the `RenderHelmChart` resource from `FunctionConfig`.
 
-## Handling of `internal.config.kubernetes.io/path` Annotation
-
-The path annotation is constructed from the chart and release name,
-which are inserted as path before the final filename, which is
-generated from the rendered resource Kind and Name:
-
-```
-PathAnno := <chart-name>/<chart-release-name>/<resource-kind>_<resource-name>.yaml
-```
-
-Given the following `RenderHelmChart` input:
-
-```
-# some/path/chart-render.yaml
-apiVersion: experimental.helm.sh/v1alpha1
-kind: RenderHelmChart
-metadata:
-  name: cert-manager
-...
-templateOptions:
-  releaseName: cert-manager-release
-```
-
-Generated resources will have a path annotation like:
-
-```
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: cert-manager
-  annotations:
-   internal.config.kubernetes.io/path: cert-manager/cert-manager-release/deployment_cert-manager.yaml
-```
-
 ## Example Usage
 
 The file `examples/render-helm-chart/cert-manager-chart.yaml` have an

--- a/examples/helm-upgrader/krm-cert-manager.yaml
+++ b/examples/helm-upgrader/krm-cert-manager.yaml
@@ -4,6 +4,7 @@ metadata:
   name: render-chart
   annotations:
     config.kubernetes.io/local-config: "true"
+    experimental.helm.sh/upgrade-constraint: "<=1.12.1"
 helmCharts:
 - chartArgs:
     name: cert-manager

--- a/examples/helm-upgrader/krm-metacontroller.yaml
+++ b/examples/helm-upgrader/krm-metacontroller.yaml
@@ -4,6 +4,7 @@ metadata:
   name: render-chart
   annotations:
     config.kubernetes.io/local-config: "true"
+    experimental.helm.sh/upgrade-constraint: "<=4.10.0"
 helmCharts:
 - chartArgs:
     name: metacontroller-helm

--- a/examples/render-helm-chart2/argo-workflows.yaml
+++ b/examples/render-helm-chart2/argo-workflows.yaml
@@ -1,0 +1,14 @@
+apiVersion: fn.kpt.dev/v1alpha1
+kind: RenderHelmChart
+metadata:
+  name: render-chart
+  annotations:
+    config.kubernetes.io/local-config: "true"
+helmCharts:
+- chartArgs:
+    name: argo-workflows
+    version: 0.31.0
+    repo: https://argoproj.github.io/argo-helm
+  templateOptions:
+    releaseName: argo-workflows
+    namespace: argo-workflow-ns

--- a/pkg/helmspecs/helmspecs.go
+++ b/pkg/helmspecs/helmspecs.go
@@ -2,6 +2,7 @@ package helmspecs
 
 import (
 	"fmt"
+
 	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
@@ -11,26 +12,26 @@ type HelmChart struct {
 	Options HelmTemplateOptions `json:"templateOptions,omitempty" yaml:"templateOptions,omitempty"`
 }
 type HelmChartArgs struct {
-	Name     string `json:"name,omitempty" yaml:"name,omitempty"`
-	Version  string `json:"version,omitempty" yaml:"version,omitempty"`
-	Repo     string `json:"repo,omitempty" yaml:"repo,omitempty"`
-	Registry string `json:"registry,omitempty" yaml:"registry,omitempty"`
+	Name     string                    `json:"name,omitempty" yaml:"name,omitempty"`
+	Version  string                    `json:"version,omitempty" yaml:"version,omitempty"`
+	Repo     string                    `json:"repo,omitempty" yaml:"repo,omitempty"`
+	Registry string                    `json:"registry,omitempty" yaml:"registry,omitempty"`
 	Auth     *kyaml.ResourceIdentifier `json:"auth,omitempty" yaml:"auth,omitempty"`
 }
 type HelmTemplateOptions struct {
-	ApiVersions []string `json:"apiVersions,omitempty" yaml:"apiVersions,omitempty"`
-	ReleaseName string   `json:"releaseName,omitempty" yaml:"releaseName,omitempty"`
-	Namespace string     `json:"namespace,omitempty" yaml:"namespace,omitempty"`
-	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
-	NameTemplate string  `json:"nameTemplate,omitempty" yaml:"nameTemplate,omitempty"`
-	IncludeCRDs bool     `json:"includeCRDs,omitempty" yaml:"includeCRDs,omitempty"`
-	SkipTests bool       `json:"skipTests,omitempty" yaml:"skipTests,omitempty"`
-	Values HelmValues    `json:"values,omitempty" yaml:"values,omitempty"`
+	APIVersions  []string   `json:"apiVersions,omitempty" yaml:"apiVersions,omitempty"`
+	ReleaseName  string     `json:"releaseName,omitempty" yaml:"releaseName,omitempty"`
+	Namespace    string     `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Description  string     `json:"description,omitempty" yaml:"description,omitempty"`
+	NameTemplate string     `json:"nameTemplate,omitempty" yaml:"nameTemplate,omitempty"`
+	IncludeCRDs  bool       `json:"includeCRDs,omitempty" yaml:"includeCRDs,omitempty"`
+	SkipTests    bool       `json:"skipTests,omitempty" yaml:"skipTests,omitempty"`
+	Values       HelmValues `json:"values,omitempty" yaml:"values,omitempty"`
 }
 type HelmValues struct {
-	ValuesFiles []string `json:"valuesFiles,omitempty" yaml:"valuesFiles,omitempty"`
+	ValuesFiles  []string       `json:"valuesFiles,omitempty" yaml:"valuesFiles,omitempty"`
 	ValuesInline map[string]any `json:"valuesInline,omitempty" yaml:"valuesInline,omitempty"`
-	ValuesMerge string    `json:"valuesMerge,omitempty" yaml:"valuesMerge,omitempty"`
+	ValuesMerge  string         `json:"valuesMerge,omitempty" yaml:"valuesMerge,omitempty"`
 }
 
 // https://catalog.kpt.dev/render-helm-chart/v0.2/
@@ -66,19 +67,20 @@ func ParseKptSpec(b []byte) (*RenderHelmChart, error) {
 
 func (spec *RenderHelmChart) IsValidSpec() error {
 	if spec.Kind != "RenderHelmChart" {
-		return fmt.Errorf("Unsupported kind: %s", spec.Kind)
+		return fmt.Errorf("unsupported kind: %s", spec.Kind)
 	}
-	for _, chart := range spec.Charts {
+	for idx := range spec.Charts {
+		chart := &spec.Charts[idx]
 		if chart.Args.Name == "" || chart.Args.Version == "" || chart.Args.Repo == "" {
-			return fmt.Errorf("Chart name, version or repo cannot be empty (%s,%s,%s)",
+			return fmt.Errorf("chart name, version or repo cannot be empty (%s,%s,%s)",
 				chart.Args.Name, chart.Args.Version, chart.Args.Repo)
 		}
 		if chart.Args.Auth != nil {
 			if chart.Args.Auth.Kind != "Secret" {
-				return fmt.Errorf("Chart auth kind must be 'Secret'")
+				return fmt.Errorf("chart auth kind must be 'Secret'")
 			}
-			if len(chart.Args.Auth.Name) == 0 {
-				return fmt.Errorf("Chart auth name must be defined")
+			if chart.Args.Auth.Name == "" {
+				return fmt.Errorf("chart auth name must be defined")
 			}
 		}
 	}
@@ -91,7 +93,7 @@ func ParseArgoCDSpec(b []byte) (*ArgoCDHelmApp, error) {
 		return nil, err
 	}
 	if !app.IsValidSpec() {
-		return app, fmt.Errorf("Invalid chart spec: %+v\n", app)
+		return app, fmt.Errorf("invalid chart spec: %+v", app)
 	}
 	return app, nil
 }

--- a/pkg/semver/semver.go
+++ b/pkg/semver/semver.go
@@ -2,8 +2,9 @@ package semver
 
 import (
 	"fmt"
-	version "github.com/Masterminds/semver"
 	"sort"
+
+	version "github.com/Masterminds/semver"
 )
 
 func Sort(versionsRaw []string) []*version.Version {
@@ -30,7 +31,7 @@ func Sort(versionsRaw []string) []*version.Version {
 func Upgrade(versions []string, constraint string) (string, error) {
 	constraints, err := version.NewConstraint(constraint)
 	if err != nil {
-		return "", fmt.Errorf("Error parsing constraint %q: %q", constraint, err.Error())
+		return "", fmt.Errorf("error parsing constraint %q: %q", constraint, err.Error())
 	}
 	vers := Sort(versions)
 	for _, v := range vers {
@@ -38,5 +39,5 @@ func Upgrade(versions []string, constraint string) (string, error) {
 			return v.Original(), nil
 		}
 	}
-	return "", fmt.Errorf("No version found that satisfies constraint: %q", constraint)
+	return "", fmt.Errorf("no version found that satisfies constraint: %q", constraint)
 }

--- a/pkg/semver/semver_test.go
+++ b/pkg/semver/semver_test.go
@@ -15,12 +15,12 @@ func TestUpgrade(t *testing.T) {
 		{"*", "v1.4.0"},
 	}
 	for _, test := range combs {
-		new_v, err := Upgrade(versions, test.constraint)
+		newVer, err := Upgrade(versions, test.constraint)
 		if err != nil {
 			t.Errorf("Semver upgrade failure %q", err.Error())
 		}
-		if new_v != test.expect {
-			t.Errorf("Semver upgrade mismatch, got %q from test %+v", new_v, test)
+		if newVer != test.expect {
+			t.Errorf("Semver upgrade mismatch, got %q from test %+v", newVer, test)
 		}
 	}
 }

--- a/pkg/skopeo/skopeo.go
+++ b/pkg/skopeo/skopeo.go
@@ -3,9 +3,10 @@ package skopeo
 import (
 	"bytes"
 	"fmt"
-	t "github.com/michaelvl/helm-upgrader/pkg/helmspecs"
 	"os/exec"
 	"regexp"
+
+	t "github.com/michaelvl/helm-upgrader/pkg/helmspecs"
 	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
@@ -22,7 +23,7 @@ func Run(args ...string) ([]byte, error) {
 	cmd.Stderr = stderr
 	err := cmd.Run()
 	if err != nil {
-		return nil, fmt.Errorf("Error running skopeo command: %q: %q", args, err.Error())
+		return nil, fmt.Errorf("error running skopeo command: %q: %q", args, err.Error())
 	}
 	return stdout.Bytes(), nil
 }
@@ -36,7 +37,7 @@ func ListTags(chart t.HelmChartArgs) (*RepoTags, error) {
 
 	var search RepoTags
 	if err := kyaml.Unmarshal(out, &search); err != nil {
-		return nil, fmt.Errorf("Error parsing skopeo output: %q", err.Error())
+		return nil, fmt.Errorf("error parsing skopeo output: %q", err.Error())
 	}
 	return &search, nil
 }


### PR DESCRIPTION
This PR deletes the code, that sets the `internal.config.kubernetes.io/path`, Setting this is unnecessary since `kpt fn sink` will set it. Also, the current solution did not handle charts that render the same resource kind with the same name for two namespaces since it did not include namespace in the path.